### PR TITLE
	you can now add environment settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /cache/*
 /bower_components
 /config/users.json
+/config/env_settings.json
 /composer.phar
 /data/confi*.json
 /logs/*.log
@@ -11,3 +12,5 @@
 /web/packages.json
 !.gitkeep
 !bin/console
+.idea
+config/deploy_settings.rb

--- a/README.md
+++ b/README.md
@@ -37,3 +37,15 @@ Run test suite
  $ php -Slocalhost:8000 -tweb
  $ ./bin/behat
 ```
+
+Troubleshooting
+---------------
+
+If you cannot build satis repository check your prod.log looking for a message of lost HOME or COMPOSER_HOME environment variable, 
+this can be fixed with: 
+
+```sh
+
+ $ php bin/console setting:add COMPOSER_HOME /whatever/is/your/composer/home
+
+```

--- a/config/prod.php
+++ b/config/prod.php
@@ -5,6 +5,16 @@ $this['gaufrette.adapter.class'] = 'Local';
 $this['gaufrette.options']       = array($this['app.data_dir']);
 $this['app.node_path']           = '/usr/bin/node';
 
+if (!is_file($this['app.env_settings_file'])) {
+    file_put_contents($this['app.env_settings_file'], json_encode([]));
+}
+$settings = json_decode(file_get_contents($this['app.env_settings_file']), true);
+if ($settings) {
+    foreach ($settings as $key => $value) {
+        putenv(sprintf('%s=%s', $key, $value));
+    }
+}
+
 $this['satis_runner'] = $this->share(function() {
     return new SatisAdmin\Runner\SatisRunner(
         $this['model_manager'],

--- a/src/SatisAdmin/Application.php
+++ b/src/SatisAdmin/Application.php
@@ -58,6 +58,7 @@ class Application extends BaseApplication
         $this['app.resources_dir']  = $this['app.root_dir'].'/resources';
         $this['app.web_dir']        = $this['app.root_dir'].'/web';
         $this['app.users_file']     = $this['app.config_dir'].'/users.json';
+        $this['app.env_settings_file']  = $this['app.config_dir'].'/env_settings.json';
 
         require sprintf('%s/%s.php', $this['app.config_dir'], $env);
     }

--- a/src/SatisAdmin/Console/AddEnvSettingCommand.php
+++ b/src/SatisAdmin/Console/AddEnvSettingCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SatisAdmin\Console;
+
+use Monolog\Logger;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class AddSettingCommand
+ * @package SatisAdmin\Console
+ * @author Noel García <noel@wearemarketing.com>
+ */
+class AddEnvSettingCommand extends BaseCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('setting:add')
+            ->setDescription('Adds a new environment setting')
+            ->addArgument('key', InputArgument::REQUIRED, 'The setting key')
+            ->addArgument('value', InputArgument::REQUIRED, 'The setting value');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $app   = $this->getApp();
+        $key = $input->getArgument('key');
+        $value = $input->getArgument('value');
+        $settings = is_file($app['app.env_settings_file']) ? json_decode(file_get_contents($app['app.env_settings_file']), true) : [];
+
+        $settings[$key] = $value;
+        file_put_contents($app['app.env_settings_file'], json_encode($settings, JSON_PRETTY_PRINT));
+
+        $app->log('Setting added', [$key => $value], Logger::INFO);
+    }
+}

--- a/src/SatisAdmin/Console/Application.php
+++ b/src/SatisAdmin/Console/Application.php
@@ -54,6 +54,7 @@ class Application extends BaseApplication
             [
                 new BuildCommand,
                 new AddUserCommand,
+                new AddEnvSettingCommand,
                 new RemoveUserCommand,
                 new AsseticDumpCommand,
             ]


### PR DESCRIPTION
If you cannot build satis repository due to unexistant HOME or COMPOSER_HOME environment variable, now you can run

php bin/console setting:add COMPOSER_HOME /whatever/is/your/composer/home

to add the environment variable
